### PR TITLE
Lien clickup → tache clickup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 #### Tache Clickup
 
-[#{clickupTicketId}](https://app.clickup.com/t/{clickupTicketId})
+[#clickupTicketId](https://app.clickup.com/t/clickupTicketId)
 
 #### Quel est le comportement actuel?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 - [ ] Feature
 - [ ] Proof of Concept
 
-#### Lien Clickup : 
+#### Tache Clickup
 
 #### Quel est le comportement actuel?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,8 @@
 
 #### Tache Clickup
 
+[#{clickupTicketId}](https://app.clickup.com/t/{clickupTicketId})
+
 #### Quel est le comportement actuel?
 
 #### Quel est le nouveau comportement ?


### PR DESCRIPTION
Si on mets le lien, alors clickup ne parse pas et ne fait pas le lien en automatique dans la tache.

Renommer en "tache clickup" permet de ne pas inciper à mettre le lien.

En vrai c'est aussi chiant (mais moins pire côté clickup), car on perd le lien direct dans la description et il faut aller voir le commentaire en dessous, qui n'est pas fait par un bot 🤦 
