### PR TITLE
Inversion du comportement actuel / nouveau comportement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-### Nouveau comportement
-
 ### Comportement actuel
+
+### Nouveau comportement
 
 ### Tache Clickup
 
@@ -10,13 +10,6 @@
 
 <!--
 ### Contexte
-
-Utiliser ou créer l'un des labels suivants pour spécifier le périmètre et le type de la Pull Request :
-
-- "scope: pompier", "scope: focus", "scope: tâche annexe"
-- "type: bugfix", "type: feature", "type: poc"
-
-Voir https://github.com/mapado/ticketing/labels pour un exemple
 
 ### Autres informations
 -->


### PR DESCRIPTION
### Nouveau comportement

Je propose d'inverser "Nouveau comportement" et "Comportement actuel"
J'en profite aussi pour enlever le commentaire sur les "labels"

### Comportement actuel

Le "comportement actuel", qui était finalement "ce qui se passait avant" se trouve "après" dans la description de PR.

<!--
### Contexte

Utiliser ou créer l'un des labels suivants pour spécifier le périmètre et le type de la Pull Request :

- "scope: pompier", "scope: focus", "scope: tâche annexe"
- "type: bugfix", "type: feature", "type: poc"

Voir https://github.com/mapado/ticketing/labels pour un exemple

### Autres informations
-->
