### PR TITLE
template: remove link since it is generated by clickup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### Tache Clickup
 
-[#clickupTicketId](https://app.clickup.com/t/clickupTicketId)
+#clickupTicketId
 
 ### Dépendances (pull requests) :
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,8 @@
 
 #clickupTicketId
 
+https://app.clickup.com/t/clickupTicketId
+
 ### Dépendances (pull requests) :
 
 <!--


### PR DESCRIPTION
### Comportement actuel

Le template incite à mettre un lien vers la tâche clickup or mettre le lien ne trigger pas le binding avec clickup. Il faut juste mettre l'id de la tâche et clickup se charge de mettre le lien dans github via un commentaire

### Nouveau comportement
Exemple PR où on met un lien VS juste l'id

https://user-images.githubusercontent.com/108657569/232424261-e9f2f135-32ff-4cff-b7d5-701cd5c6f0a3.mov




### Tache Clickup

[#clickupTicketId](https://app.clickup.com/t/clickupTicketId)

### Dépendances (pull requests) :

<!--
### Contexte

### Autres informations
-->
