### PR TITLE
Try to avoid #clickupTicketId

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 
 ### Tache Clickup
 
+<!-- Pensez à supprimer ce block si aucune tâche clickup n'est liée ! -->
+
 #clickupTicketId
 
 https://app.clickup.com/t/clickupTicketId

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,9 @@ https://app.clickup.com/t/clickupTicketId
 
 ### Dépendances (pull requests) :
 
+<!-- Pensez à supprimer ce block si aucune PR n'est liée ! -->
+
+<!-- Si besoin, vous pouvez ajouter du contexte ou des informations supplémentaires -->
 <!--
 ### Contexte
 


### PR DESCRIPTION
### Comportement actuel

Pas mal de gens laissent le pâté "Tache Clickup" avec des "#clickupTicketId"

### Nouveau comportement

J'ajoute un message pour que le bloc soit supprimer quand il n'y a pas de tâche clickup liée
