### PR TITLE
Remove huge espace between Clickup task id and clickup url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,7 @@
 
 ### Tache Clickup
 
-#clickupTicketId
-
-https://app.clickup.com/t/clickupTicketId
+#clickupTicketId / https://app.clickup.com/t/clickupTicketId
 
 ### Dépendances (pull requests) :
 


### PR DESCRIPTION
### Nouveau comportement

Le but est d'enlever l'énorme espace et surtout la séparation trop distincte entre l'url et l'id.
Ca me stresse tout cet espace 🤯 

<!--
### Contexte

### Autres informations
-->
